### PR TITLE
Light text in Dark Mode for example step navigation

### DIFF
--- a/src/components/InteractiveCodeExample.rs
+++ b/src/components/InteractiveCodeExample.rs
@@ -255,7 +255,7 @@ fn ExampleComponent(
                     view! { cx, <div class="h-8"></div> }
                 }
             >
-                <div class="h-8 flex justify-around w-full">
+                <div class="h-8 flex justify-around w-full dark:text-white">
                     <button on:click=move |_| set_phase.update(OnStep::prev)>
                         "〈 Previous Step"
                     </button>


### PR DESCRIPTION
Couldn't read the "Previous Step" and "Next Step" buttons. Updated them to have light text in dark mode.

Before:
<img width="635" alt="Screenshot 2023-06-30 at 4 42 59 PM" src="https://github.com/leptos-rs/leptos-website/assets/123515925/c122c0c2-54c0-4261-afd3-3fdf09bab2fa">

Now:
<img width="628" alt="Screenshot 2023-06-30 at 4 42 49 PM" src="https://github.com/leptos-rs/leptos-website/assets/123515925/4987ef63-64aa-46e2-9889-a04fd486c6b1">
